### PR TITLE
Patch 84

### DIFF
--- a/src/Blueprint.h
+++ b/src/Blueprint.h
@@ -136,6 +136,9 @@ namespace snowcrash {
         
         /** Schema */
         Asset schema;
+
+        /** Lazy References */
+        Collection<Payload*>::type lazyReferences;
     };
     
     /** Resource Model */

--- a/src/PayloadParser.h
+++ b/src/PayloadParser.h
@@ -388,18 +388,15 @@ namespace snowcrash {
                 // Process a symbol reference
                 ResourceModelSymbolTable::const_iterator symbolEntry = parser.symbolTable.resourceModels.find(symbol);
                 if (symbolEntry == parser.symbolTable.resourceModels.end()) {
-                    
-                    // ERR: Undefined symbol
-                    std::stringstream ss;
-                    ss << "undefined symbol '" << symbol << "'";
-                    result.first.error = Error(ss.str(),
-                                               SymbolError,
-                                               MapSourceDataBlock(symbolSourceMap, parser.sourceData));
-                    return result;
+                    ResourceModel resModel;
+                    resModel.name = symbol;
+                    resModel.lazyReferences.push_back(&payload);
+                    parser.symbolTable.resourceModels[payload.name] = resModel;
                 }
-                
-                // Retrieve payload from symbol table
-                payload = symbolEntry->second;
+                else {
+                    // Retrieve payload from symbol table
+                    payload = symbolEntry->second;
+                }
             }
             else {
                 // Parse as an asset

--- a/src/ResourceParser.h
+++ b/src/ResourceParser.h
@@ -348,15 +348,28 @@ namespace snowcrash {
                 parser.symbolTable.resourceModels[payload.name] = payload;
             }
             else {
-                // ERR: Symbol already defined
-                std::stringstream ss;
-                ss << "symbol '" << payload.name << "' already defined";
+                if (parser.symbolTable.resourceModels[payload.name].lazyReferences.empty()) {
+                    // ERR: Symbol already defined
+                    std::stringstream ss;
+                    ss << "symbol '" << payload.name << "' already defined";
 
-                BlockIterator nameBlock = ListItemNameBlock(cur, section.bounds.second);
-                SourceCharactersBlock sourceBlock = CharacterMapForBlock(nameBlock, cur, section.bounds, parser.sourceData);
-                result.first.error = Error(ss.str(),
-                                           SymbolError,
-                                           sourceBlock);
+                    BlockIterator nameBlock = ListItemNameBlock(cur, section.bounds.second);
+                    SourceCharactersBlock sourceBlock = CharacterMapForBlock(nameBlock, cur, section.bounds, parser.sourceData);
+                    result.first.error = Error(ss.str(),
+                                               SymbolError,
+                                               sourceBlock);
+                } else {
+                    // Resolve lazyReferences
+                    std::stringstream ss;
+                    ss << "TODO symbol '" << payload.name << "' already defined";
+
+                    BlockIterator nameBlock = ListItemNameBlock(cur, section.bounds.second);
+                    SourceCharactersBlock sourceBlock = CharacterMapForBlock(nameBlock, cur, section.bounds, parser.sourceData);
+                    result.first.error = Error(ss.str(),
+                                               SymbolError,
+                                               sourceBlock);
+                    parser.symbolTable.resourceModels[payload.name].lazyReferences.clear();
+                }
             }
             
             // Assign model


### PR DESCRIPTION
I'd have gone a different way - just creating references, i.e. mapping the semantics of markdown.
And then resolving those references only at the end of the blueprint parsing. On the line of lexing, parsing, validating.

But I want to keep this exercise limited in its footprint, so my approach is
- DONE amended the ResourceModel (Payload) with lazyReferences - a pointer collection of Payloads
- DONE a resourceModel is added to parser.symbolTable.resourceModels if one is not found, and should keep a pointer to payloads that reference it
- PLACEHOLDER when a resource model is about to be re-defined, check if it has any lazyReferences and resolve them, instead of failing with "already defined"
- TODO check for resourceModels with non-empty lazyReferences and throw errors for undefined symbols

/ping @zdne
